### PR TITLE
Rename subscription 'user' to 'subscriber'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432
       DEVISE_SECRET_KEY: devise-ci-secret-key
       STRIPE_SECRET_KEY: sk_test_abc123
+      WHAT3WORDS_API_KEY: some-what3words-api-key
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       DEVISE_SECRET_KEY: devise-ci-secret-key
       STRIPE_SECRET_KEY: sk_test_abc123
       WHAT3WORDS_API_KEY: some-what3words-api-key
+      HERE_MAPS_API_KEY: some-here-maps-api-key
 
     services:
       postgres:

--- a/app.json
+++ b/app.json
@@ -10,7 +10,8 @@
   "env": {
     "DEVISE_SECRET_KEY": "devise-secret-key",
     "HASHIDS_SALT": "some-hashids-salt",
-    "RAILS_ENV": "test"
+    "RAILS_ENV": "test",
+    "WHAT3WORDS_API_KEY": "some-what3words-api-key"
   },
   "environments": {
     "test": {

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -9,11 +9,11 @@ module Admin
       @subscriptions = Subscription.all
       @subscriptions = @subscriptions.where(stripe_status: params[:stripe_status].compact_blank.map { |x| x == 'BLANK' ? nil : Subscription.stripe_statuses.fetch(x) }) if params[:stripe_status]
       @subscriptions = @subscriptions.where('stripe_id LIKE ?', "%#{params[:stripe_id]}%") if params[:stripe_id].present?
-      @subscriptions = @subscriptions.joins(:user).where(users: { id: User.decode_id(params[:user_id]) }) if params[:user_id].present?
+      @subscriptions = @subscriptions.joins(:subscriber).where(users: { id: User.decode_id(params[:subscriber_id]) }) if params[:subscriber_id].present?
 
       respond_to do |format|
         format.html do
-          @subscriptions = @subscriptions.includes(:user, :tile).order(id: :desc).page(params[:page])
+          @subscriptions = @subscriptions.includes(:subscriber, :tile).order(id: :desc).page(params[:page])
           render :index
         end
         format.csv { render_csv('subscriptions') }

--- a/app/controllers/admin/tiles_controller.rb
+++ b/app/controllers/admin/tiles_controller.rb
@@ -23,7 +23,7 @@ module Admin
       when 'false'
         @tiles = @tiles.where.missing(:latest_subscription)
       end
-      @tiles = @tiles.order(id: :desc).includes(latest_subscription: :user).page(params[:page])
+      @tiles = @tiles.order(id: :desc).includes(latest_subscription: :subscriber).page(params[:page])
     end
 
     def show; end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -24,17 +24,18 @@ class StaticPagesController < ApplicationController
   def my_tile
     log_event_mixpanel('My Tile Shortcut', { authed: true })
 
-    if current_user.subscriptions.none?
+    subs = current_user.subscriptions_subscribed
+    if subs.none?
       redirect_to root_path,
                   alert: "You don't have a subscription yet"
-    elsif current_user.subscriptions.stripe_status_active.none?
+    elsif subs.stripe_status_active.none?
       redirect_to subscriptions_path,
                   alert: 'Your subscription is not active'
-    elsif current_user.subscriptions.stripe_status_active.joins(:tile).none?
+    elsif subs.stripe_status_active.joins(:tile).none?
       redirect_to subscriptions_path,
                   alert: "You're subscribed, but haven't claimed a tile yet!"
     else
-      claimed_subs = current_user.subscriptions.stripe_status_active.joins(:tile)
+      claimed_subs = subs.stripe_status_active.joins(:tile)
       if claimed_subs.size > 1
         redirect_to subscriptions_path,
                     notice: "You've got multiple active tile subscriptions; choose one to view below."

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -37,14 +37,14 @@ class SubscriptionsController < ApplicationController
         redirect_to support_path, flash: { danger: 'That link is missing something; please contact us.' }
       elsif !ActiveSupport::SecurityUtils.secure_compare(@subscription.claim_hash, params[:hash])
         redirect_to support_path, flash: { danger: "That link doesn't look quite right; please contact us." }
-      elsif @subscription.user.present?
-        if @subscription.user == current_user
+      elsif @subscription.subscriber.present?
+        if @subscription.subscriber == current_user
           redirect_to welcome_project_path(@subscription.project_fallback), flash: { notice: 'This subscription is already linked to your account' }
         else
           redirect_to support_path, flash: { danger: 'Oh! This subscription is already connected to a different account. Have you got two accounts? Please reach out to us and we can help.' }
         end
       else
-        @subscription.update!(user: current_user)
+        @subscription.update!(subscriber: current_user)
         redirect_to welcome_project_path(@subscription.project_fallback), flash: { notice: "Great; you've subscribed! Next step is to pick a tile!" }
       end
     else

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -9,7 +9,7 @@ class SubscriptionsController < ApplicationController
 
   def index
     log_event_mixpanel('Subscriptions: Index')
-    @subscriptions = current_user.subscriptions.includes(tile: { plot: :project })
+    @subscriptions = current_user.subscriptions_subscribed.includes(tile: { plot: :project })
   end
 
   def show

--- a/app/controllers/webhook/stripe_controller.rb
+++ b/app/controllers/webhook/stripe_controller.rb
@@ -37,7 +37,7 @@ module Webhook
 
       # TODO: Check tile still available?
 
-      subscr = Subscription.create!(user:, tile:, stripe_id: sub_id, stripe_status: :incomplete)
+      subscr = Subscription.create!(subscriber: user, tile:, stripe_id: sub_id, stripe_status: :incomplete)
 
       handle_external_checkout(subscr) if user.nil?
 

--- a/app/models/plot.rb
+++ b/app/models/plot.rb
@@ -113,7 +113,7 @@ class Plot < ApplicationRecord
   end
 
   def tiles_subscribed_by(user)
-    tiles.joins(latest_subscription: :user).where(users: { id: user.id }).includes(:latest_subscription)
+    tiles.joins(latest_subscription: :subscriber).where(users: { id: user.id }).includes(:latest_subscription)
   end
 
   def tiles_for_map(include_tile: nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,7 +18,7 @@ class Project < ApplicationRecord
   end
 
   def tiles_subscribed_by(user)
-    Tile.joins(latest_subscription: :user, plot: :project)
+    Tile.joins(latest_subscription: :subscriber, plot: :project)
         .where(projects: { id: })
         .where(users: { id: user.id })
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Subscription < ApplicationRecord
-  belongs_to :user, optional: true
+  belongs_to :subscriber, class_name: 'User', inverse_of: :subscriptions_subscribed, optional: true
   belongs_to :tile, optional: true
 
   validates :stripe_id,

--- a/app/models/tile.rb
+++ b/app/models/tile.rb
@@ -120,6 +120,6 @@ class Tile < ApplicationRecord
   end
 
   def viewable_by?(user)
-    latest_subscription&.user == user
+    latest_subscription&.subscriber == user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   belongs_to :team, optional: true
 
-  has_many :subscriptions, dependent: :restrict_with_exception
+  has_many :subscriptions_subscribed, class_name: 'Subscription', foreign_key: 'subscriber_id', inverse_of: :subscriber, dependent: :restrict_with_exception
   has_many :posts_authored, class_name: 'Post', foreign_key: 'author_id', inverse_of: :author, dependent: :restrict_with_exception
   has_many :post_views, class_name: 'PostView', inverse_of: :user, dependent: :destroy
   has_many :comments_authored, class_name: 'Comment', inverse_of: :author, dependent: :restrict_with_exception
@@ -29,9 +29,11 @@ class User < ApplicationRecord
   end
 
   def subscription_for_plot(plot)
-    subscriptions.joins(:tile)
-                 .where(tiles: { plot_id: plot.id })
-                 .order(id: :desc).first # assume last = most likely to be active
+    subscriptions_subscribed
+      .joins(:tile)
+      .where(tiles: { plot_id: plot.id })
+      .order(id: :desc)
+      .first # assume latest is most likely to be active
   end
 
   private

--- a/app/views/admin/subscriptions/_filters.html.erb
+++ b/app/views/admin/subscriptions/_filters.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag(admin_subscriptions_path, method: :get, class: 'row g-3 mb-3') do %>
-  <%= render_filter_text(:user_id, 'User ID', col: 2) %>
+  <%= render_filter_text(:subscriber_id, 'Subscriber User ID', col: 2) %>
 
   <%= render_filter_text(:stripe_id, 'Stripe ID', col: 2) %>
 

--- a/app/views/admin/subscriptions/_table.html.erb
+++ b/app/views/admin/subscriptions/_table.html.erb
@@ -17,10 +17,10 @@
       <tr>
         <td><%= link_to subscription.hashid, admin_subscription_path(subscription) %></td>
         <td>
-          <% if subscription.user.present? %>
-            <%= link_to subscription.user.full_name, admin_user_path(subscription.user) %>
+          <% if subscription.subscriber.present? %>
+            <%= link_to subscription.subscriber.full_name, admin_user_path(subscription.subscriber) %>
             <br>
-            <%= subscription.user.email %>
+            <%= subscription.subscriber.email %>
           <% else %>
             Unregistered; email from stripe is
             <%= content_tag(:code, subscription.claim_email || 'NOT SET') %>

--- a/app/views/admin/subscriptions/index.csv.erb
+++ b/app/views/admin/subscriptions/index.csv.erb
@@ -1,7 +1,7 @@
 <%- headers = [
   'Subscription ID',
-  'User ID',
-  'User Email',
+  'Subscriber User ID',
+  'Subscriber Email',
   'Tile ID',
   'Created At',
   'Stripe ID',
@@ -15,8 +15,8 @@
 <%- @subscriptions.each do |subscription| -%>
 <%= CSV.generate_line([
     subscription.hashid,
-    subscription.user&.hashid,
-    subscription.user&.email,
+    subscription.subscriber&.hashid,
+    subscription.subscriber&.email,
     subscription.tile&.hashid,
     subscription.created_at,
     subscription.stripe_id,

--- a/app/views/admin/subscriptions/show.html.erb
+++ b/app/views/admin/subscriptions/show.html.erb
@@ -5,9 +5,9 @@
     <tr>
       <th>User</th>
       <td>
-        <% if @subscription.user.present? %>
-          <%= link_to @subscription.user.full_name, admin_user_path(@subscription.user) %>
-          <%= " (that's you!)" if @subscription.user == current_user %>
+        <% if @subscription.subscriber.present? %>
+          <%= link_to @subscription.subscriber.full_name, admin_user_path(@subscription.subscriber) %>
+          <%= " (that's you!)" if @subscription.subscriber == current_user %>
         <% else %>
           No user; purchase not yet claimed.
           <% if @subscription.claim_hash.nil? %>

--- a/app/views/admin/tiles/_subscription_info.html.erb
+++ b/app/views/admin/tiles/_subscription_info.html.erb
@@ -4,10 +4,10 @@
     <%= link_to 'subscribed',
                 admin_subscription_path(@tile.latest_subscription) %>
 
-    <% if @tile.latest_subscription.user.present? %>
+    <% if @tile.latest_subscription.subscriber.present? %>
       by
-      <%= link_to @tile.latest_subscription.user.display_name,
-                  admin_user_path(@tile.latest_subscription.user) %>
+      <%= link_to @tile.latest_subscription.subscriber.display_name,
+                  admin_user_path(@tile.latest_subscription.subscriber) %>
     <% else %>
       (but not claimed yet)
     <% end %>

--- a/app/views/admin/tiles/_table.html.erb
+++ b/app/views/admin/tiles/_table.html.erb
@@ -27,7 +27,7 @@
             <% end %>
           </td>
         <% end %>
-        <td><%= tile.latest_subscription&.user&.email || '-' %></td>
+        <td><%= tile.latest_subscription&.subscriber&.email || '-' %></td>
         <td><%= link_to 'W3W', tile.w3w_url %></td>
         <td><%= link_to 'Details', admin_tile_path(tile) %></td>
       </tr>

--- a/app/views/admin/users/_details.html.erb
+++ b/app/views/admin/users/_details.html.erb
@@ -44,9 +44,9 @@
 
 <p>
   <strong>Subscriptions:</strong>
-  <%= user.subscriptions.size %>
+  <%= user.subscriptions_subscribed.size %>
   -
-  <%= link_to 'view', admin_subscriptions_path(user_id: user.hashid) %>
+  <%= link_to 'view', admin_subscriptions_path(subscriber_id: user.hashid) %>
 </p>
 
 <p>

--- a/app/views/plots/_card.html.erb
+++ b/app/views/plots/_card.html.erb
@@ -11,10 +11,15 @@
     <h5 class="card-title"><%= plot.title %></h5>
 
     <p class="card-text">
-      <%= plot.non_subscribed_tiles.size %>
-      of
-      <%= plot.tiles.size %>
-      tiles available
+      <% non_subscribed_tiles_count = plot.non_subscribed_tiles.size %>
+      <% if non_subscribed_tiles_count.zero? %>
+        There are no tiles available
+      <% else %>
+        <%= plot.non_subscribed_tiles.size %>
+        of
+        <%= plot.tiles.size %>
+        tiles available
+      <% end %>
     </p>
     <%= link_to 'View Plot',
                 plot_path(plot),

--- a/app/views/plots/show.html.erb
+++ b/app/views/plots/show.html.erb
@@ -1,4 +1,4 @@
-<% ready_to_claim = user_signed_in? && current_user.subscriptions.where.missing(:tile).any? %>
+<% ready_to_claim = user_signed_in? && current_user.subscriptions_subscribed.where.missing(:tile).any? %>
 <% active_sub = user_signed_in? && current_user.subscription_for_plot(@plot) %>
 <% random_tile = @plot.tiles.available.sample %>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,4 +1,4 @@
-<% ready_to_claim = user_signed_in? && current_user.subscriptions.where.missing(:tile).any? %>
+<% ready_to_claim = user_signed_in? && current_user.subscriptions_subscribed.where.missing(:tile).any? %>
 
 <h1><%= title "Project: #{@project.title}" %></h1>
 

--- a/app/views/static_pages/homepage.html.erb
+++ b/app/views/static_pages/homepage.html.erb
@@ -12,9 +12,9 @@
 </p>
 
 <p>
-  <% if current_user&.subscriptions&.any? %>
+  <% if current_user&.subscriptions_subscribed&.any? %>
     <%= link_to 'Continue exploring!', explore_path, class: 'btn btn-primary' %>
-    <% if current_user.subscriptions.stripe_status_active.joins(:tile).any? %>
+    <% if current_user.subscriptions_subscribed.stripe_status_active.joins(:tile).any? %>
       or
       <%= link_to 'View my tile', my_tile_path, class: 'btn btn-primary' %>
     <% end %>

--- a/app/views/tiles/_subscription_info.html.erb
+++ b/app/views/tiles/_subscription_info.html.erb
@@ -1,7 +1,7 @@
 <p>
   <% if tile.latest_subscription.present? %>
     <p>
-      <% if tile.latest_subscription.user == current_user %>
+      <% if tile.latest_subscription.subscriber == current_user %>
         Your subscription to this tile began on
         <%= tile.latest_subscription.created_at.strftime('%e %b %Y') %>
         and is currently
@@ -10,7 +10,7 @@
         This tile is already subscribed by someone else!
       <% end %>
     </p>
-    <% if tile.latest_subscription.user == current_user %>
+    <% if tile.latest_subscription.subscriber == current_user %>
       <% if tile.latest_subscription.stripe_status_canceled? %>
         <%= bootstrap_alert 'Your subscription is inactive. To resolve this, please re-subscribe below' %>
         <%= render 'tiles/subscription_checkout', tile: tile %>
@@ -21,7 +21,7 @@
       <% end %>
     <% end %>
   <% elsif user_signed_in? %>
-    <% redeemable_subscription = current_user.subscriptions.where.missing(:tile).first %>
+    <% redeemable_subscription = current_user.subscriptions_subscribed.where.missing(:tile).first %>
     <% if redeemable_subscription.present? %>
       <%= render 'tiles/subscription_redeem', tile: tile, subscription: redeemable_subscription %>
     <% else %>

--- a/app/views/tiles/show.html.erb
+++ b/app/views/tiles/show.html.erb
@@ -1,4 +1,4 @@
-<% ready_to_claim = user_signed_in? && current_user.subscriptions.where.missing(:tile).any? %>
+<% ready_to_claim = user_signed_in? && current_user.subscriptions_subscribed.where.missing(:tile).any? %>
 <% active_sub = user_signed_in? && @tile.plot.present? && current_user.subscription_for_plot(@tile.plot) %>
 
 <% if !user_signed_in? %>

--- a/db/migrate/20240923201545_rename_subscription_user_id_to_subscriber_id.rb
+++ b/db/migrate/20240923201545_rename_subscription_user_id_to_subscriber_id.rb
@@ -1,0 +1,5 @@
+class RenameSubscriptionUserIdToSubscriberId < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :subscriptions, :user_id, :subscriber_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_10_202839) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_23_201545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -103,7 +103,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_202839) do
   end
 
   create_table "subscriptions", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "subscriber_id"
     t.bigint "tile_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -114,8 +114,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_202839) do
     t.string "claim_email"
     t.string "claim_hash"
     t.index ["stripe_id"], name: "index_subscriptions_on_stripe_id", unique: true
+    t.index ["subscriber_id"], name: "index_subscriptions_on_subscriber_id"
     t.index ["tile_id"], name: "index_subscriptions_on_tile_id"
-    t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
 
   create_table "teams", force: :cascade do |t|
@@ -169,7 +169,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_202839) do
   add_foreign_key "posts", "users", column: "author_id"
   add_foreign_key "prices", "projects"
   add_foreign_key "subscriptions", "tiles"
-  add_foreign_key "subscriptions", "users"
+  add_foreign_key "subscriptions", "users", column: "subscriber_id"
   add_foreign_key "tiles", "plots"
   add_foreign_key "tiles", "subscriptions", column: "latest_subscription_id"
   add_foreign_key "users", "teams"

--- a/lib/tasks/subscription.rake
+++ b/lib/tasks/subscription.rake
@@ -44,10 +44,10 @@ namespace :subscription do
       stripe_sub = Stripe::Subscription.retrieve(subscr.stripe_id).to_hash
       customer_id = stripe_sub.fetch(:customer)
 
-      next if customer_id == subscr.user.stripe_customer_id
+      next if customer_id == subscr.subscriber.stripe_customer_id
 
       puts "Subscription #{subscr.hashid} (stripe:#{subscr.stripe_id}) has mismatched customer_id: #{customer_id}"
-      puts "User.find_by_hashid!('#{subscr.user.hashid}').update!(stripe_customer_id: '#{customer_id}')"
+      puts "User.find_by_hashid!('#{subscr.subscriber.hashid}').update!(stripe_customer_id: '#{customer_id}')"
     end; nil
   end
 end

--- a/spec/controllers/plots_controller_show_spec.rb
+++ b/spec/controllers/plots_controller_show_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+RSpec.describe PlotsController do
+  render_views
+
+  let(:user) { create(:user) }
+  let(:project) { create(:project) }
+  let(:plot) { create(:plot) }
+  let(:tile) { create(:tile, plot:) }
+
+  describe 'GET plots#show' do
+    subject(:do_get) do
+      get :show, params: { id: plot.hashid }
+    end
+
+    before do
+      sign_in(user)
+    end
+
+    context 'when logged out' do
+      before do
+        sign_out(user)
+      end
+
+      it 'returns a 200 status code' do
+        do_get
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows login link' do
+        do_get
+
+        expect(response.body).to include(new_user_session_path)
+      end
+
+      it 'shows the plot details anyway' do
+        do_get
+
+        expect(response.body).to include(plot.title)
+      end
+    end
+
+    context 'when not subscribed to a tile' do
+      it 'returns a 200 status code' do
+        do_get
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows the plot details' do
+        do_get
+
+        expect(response.body).to include(plot.title)
+      end
+
+      it 'shows option to subscribe to the plot' do
+        do_get
+
+        expect(response.body).to match(/Click an available tile .+ to subscribe/)
+      end
+    end
+
+    context 'when subscribed to tile in current plot' do
+      let(:subscription) { create(:subscription, subscriber: user, tile:) }
+
+      before do
+        subscription
+      end
+
+      it 'returns a 200 status code' do
+        do_get
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'mentions the tile' do
+        do_get
+
+        expect(response.body).to include(tile.w3w)
+      end
+
+      it 'shows a message that you are subscribed' do
+        do_get
+
+        expect(response.body).to include('already subscribed to a tile in this plot')
+      end
+    end
+  end
+end

--- a/spec/controllers/projects_controller_show_spec.rb
+++ b/spec/controllers/projects_controller_show_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+RSpec.describe ProjectsController do
+  render_views
+
+  let(:user) { create(:user) }
+  let(:project) { create(:project) }
+  let(:plot) { create(:plot, project:) }
+  let(:tile) { create(:tile, plot:) }
+
+  describe 'GET projects#show' do
+    subject(:do_get) do
+      get :show, params: { id: project.hashid }
+    end
+
+    before do
+      sign_in(user)
+    end
+
+    context 'when logged out' do
+      before do
+        sign_out(user)
+      end
+
+      it 'returns a 200 status code' do
+        do_get
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows login link' do
+        do_get
+
+        expect(response.body).to include(new_user_session_path)
+      end
+
+      it 'shows the project details anyway' do
+        do_get
+
+        expect(response.body).to include(project.title)
+      end
+    end
+
+    context 'when not subscribed to a tile and no tiles available' do
+      before do
+        plot
+      end
+
+      it 'returns a 200 status code' do
+        do_get
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows the project details' do
+        do_get
+
+        expect(response.body).to include(project.title)
+      end
+
+      it 'shows the plot details' do
+        do_get
+
+        expect(response.body).to include(plot.title)
+      end
+
+      it 'shows option to subscribe to the project' do
+        do_get
+
+        expect(response.body).to include('There are no tiles available')
+      end
+    end
+
+    context 'when not subscribed but tiles available' do
+      before do
+        tile
+      end
+
+      it 'returns a 200 status code' do
+        do_get
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows the project details' do
+        do_get
+
+        expect(response.body).to include(project.title)
+      end
+    end
+
+    context 'when subscribed but not yet selected a tile in current project' do
+      before do
+        create(:subscription, subscriber: user)
+      end
+
+      it 'returns a 200 status code' do
+        do_get
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows a prompt to choose a tile' do
+        do_get
+
+        expect(response.body).to include('subscribed but need to choose a tile')
+      end
+    end
+  end
+end

--- a/spec/controllers/static_pages_controller_homepage_spec.rb
+++ b/spec/controllers/static_pages_controller_homepage_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe StaticPagesController do
   render_views
 
-  describe 'GET /' do
+  describe 'GET static_pages#homepage' do
     context 'when logged out' do
       it 'renders a login link' do
         get :homepage

--- a/spec/controllers/static_pages_controller_homepage_spec.rb
+++ b/spec/controllers/static_pages_controller_homepage_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe StaticPagesController do
 
   describe 'GET /' do
     context 'when logged out' do
-      it 'returns a 200 status code and login link' do
+      it 'renders a login link' do
         get :homepage
 
         expect(response).to have_http_status(:ok)
@@ -20,7 +20,7 @@ RSpec.describe StaticPagesController do
         sign_in(user)
       end
 
-      it 'returns a 200 status code and logout link' do
+      it 'renders a logout link' do
         get :homepage
 
         expect(response).to have_http_status(:ok)

--- a/spec/controllers/static_pages_controller_my_tile_spec.rb
+++ b/spec/controllers/static_pages_controller_my_tile_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe StaticPagesController do
+  describe 'GET static_pages#my_tile' do
+    subject(:do_get) do
+      get :my_tile
+    end
+
+    let(:user) { create(:user) }
+    let(:subscription) { create(:subscription, subscriber: user) }
+    let(:tile) { create(:tile) }
+
+    before do
+      sign_in(user)
+    end
+
+    context 'when logged out' do
+      before do
+        sign_out(user)
+      end
+
+      it 'redirects to login' do
+        do_get
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'with no tile' do
+      it 'redirects to homepage' do
+        do_get
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'with a tile subscribed by current user' do
+      before do
+        subscription.update!(tile:)
+      end
+
+      it 'redirects to the tile' do
+        do_get
+
+        expect(response).to redirect_to(tile_path(tile))
+      end
+    end
+  end
+end

--- a/spec/controllers/subscriptions_controller_claim_spec.rb
+++ b/spec/controllers/subscriptions_controller_claim_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe SubscriptionsController do
+  render_views
+
+  describe 'GET subscriptions#claim' do
+    let(:user) { create(:user) }
+    let(:project) { create(:project) }
+    let(:subscription) { create(:subscription, claim_hash: 'valid-claim-hash') }
+
+    before do
+      sign_in(user)
+    end
+
+    context 'when logged out' do
+      before do
+        sign_out(user)
+      end
+
+      it 'redirects to registration' do
+        get :claim, params: { id: subscription.hashid }
+
+        expect(response).to redirect_to(new_user_registration_path)
+      end
+    end
+
+    context 'with a valid claim hash' do
+      before do
+        subscription
+        project
+      end
+
+      it 'assigns user to the subscription and redirects to welcome page' do
+        get :claim, params: { id: subscription.hashid, hash: 'valid-claim-hash' }
+
+        expect(response).to redirect_to(welcome_project_path(project))
+        expect(subscription.reload.subscriber).to eq(user)
+      end
+
+      it 'silently passes if already claimed by user' do
+        get :claim, params: { id: subscription.hashid, hash: 'valid-claim-hash' }
+
+        expect(response).to redirect_to(welcome_project_path(project))
+      end
+
+      it 'rejects if already claimed by another user' do
+        subscription.update!(subscriber: create(:user))
+
+        get :claim, params: { id: subscription.hashid, hash: 'valid-claim-hash' }
+
+        expect(response).to redirect_to(support_path)
+        expect(flash[:danger]).to include('different account')
+      end
+    end
+
+    context 'with a missing claim hash' do
+      before do
+        subscription
+      end
+
+      it 'returns error and redirects to support' do
+        get :claim, params: { id: subscription.hashid }
+
+        expect(flash[:danger]).to include('link is missing something')
+        expect(response).to redirect_to(support_path)
+      end
+    end
+
+    context 'with an invalid claim hash' do
+      before do
+        subscription
+      end
+
+      it 'returns error and redirects to support' do
+        get :claim, params: { id: subscription.hashid, hash: 'not-valid' }
+
+        expect(flash[:danger]).to include("link doesn't look quite right")
+        expect(response).to redirect_to(support_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/subscriptions_controller_index_spec.rb
+++ b/spec/controllers/subscriptions_controller_index_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe SubscriptionsController do
+  render_views
+
+  describe 'GET /subscriptions' do
+    let(:user) { create(:user) }
+    let(:subscription) { create(:subscription, subscriber: user) }
+    let(:project) { create(:project) }
+    let(:tile) { create(:tile) }
+
+    before do
+      sign_in(user)
+    end
+
+    context 'when logged out' do
+      before do
+        sign_out(user)
+      end
+
+      it 'redirects to login' do
+        get :index
+
+        expect(response).to redirect_to('/users/sign_in')
+      end
+    end
+
+    context 'with a non-redeemed subscription' do
+      before do
+        subscription
+        project
+      end
+
+      it 'displays an option to choose a project tile' do
+        get :index
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Find a tile')
+        expect(response.body).to include(welcome_project_path(project))
+      end
+    end
+
+    context 'with a redeemed subscription' do
+      before do
+        subscription.update!(tile:)
+      end
+
+      it 'displays a link to the tile' do
+        get :index
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("///#{tile.w3w}")
+        expect(response.body).to include(tile_path(tile))
+      end
+    end
+  end
+end

--- a/spec/controllers/subscriptions_controller_index_spec.rb
+++ b/spec/controllers/subscriptions_controller_index_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe SubscriptionsController do
   render_views
 
-  describe 'GET /subscriptions' do
+  describe 'GET subscriptions#index' do
     let(:user) { create(:user) }
     let(:subscription) { create(:subscription, subscriber: user) }
     let(:project) { create(:project) }
@@ -21,7 +21,7 @@ RSpec.describe SubscriptionsController do
       it 'redirects to login' do
         get :index
 
-        expect(response).to redirect_to('/users/sign_in')
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
 

--- a/spec/controllers/subscriptions_controller_index_spec.rb
+++ b/spec/controllers/subscriptions_controller_index_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe SubscriptionsController do
   render_views
 
   describe 'GET subscriptions#index' do
+    subject(:do_get) do
+      get :index
+    end
+
     let(:user) { create(:user) }
     let(:subscription) { create(:subscription, subscriber: user) }
     let(:project) { create(:project) }
@@ -19,7 +23,7 @@ RSpec.describe SubscriptionsController do
       end
 
       it 'redirects to login' do
-        get :index
+        do_get
 
         expect(response).to redirect_to(new_user_session_path)
       end
@@ -32,7 +36,7 @@ RSpec.describe SubscriptionsController do
       end
 
       it 'displays an option to choose a project tile' do
-        get :index
+        do_get
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include('Find a tile')
@@ -46,7 +50,7 @@ RSpec.describe SubscriptionsController do
       end
 
       it 'displays a link to the tile' do
-        get :index
+        do_get
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("///#{tile.w3w}")

--- a/spec/controllers/tiles_controller_show_spec.rb
+++ b/spec/controllers/tiles_controller_show_spec.rb
@@ -4,15 +4,17 @@ RSpec.describe TilesController do
   render_views
 
   describe 'GET tiles#show' do
+    subject(:do_get) do
+      get :show, params: { id: tile.hashid }
+    end
+
     let(:user) { create(:user) }
-    let(:other_user) { create(:user) }
     let(:subscription) { create(:subscription, subscriber: user) }
     let(:project) { create(:project) }
     let(:tile) { create(:tile) }
 
     before do
       sign_in(user)
-      tile
     end
 
     context 'when logged out' do
@@ -21,17 +23,19 @@ RSpec.describe TilesController do
       end
 
       it 'returns a 200 status code' do
+        do_get
+
         expect(response).to have_http_status(:ok)
       end
 
       it 'shows login link' do
-        get :show, params: { id: tile.hashid }
+        do_get
 
         expect(response.body).to include(new_user_session_path)
       end
 
       it 'shows the tile details anyway' do
-        get :show, params: { id: tile.hashid }
+        do_get
 
         expect(response.body).to include(tile.w3w)
       end
@@ -39,55 +43,61 @@ RSpec.describe TilesController do
 
     context 'with an unclaimed tile' do
       it 'returns a 200 status code' do
+        do_get
+
         expect(response).to have_http_status(:ok)
       end
 
       it 'shows the tile' do
-        get :show, params: { id: tile.hashid }
+        do_get
 
         expect(response.body).to include(tile.w3w)
       end
     end
 
-    context 'with a tile subcribed by current user' do
+    context 'with a tile subscribed by current user' do
       before do
         subscription.update!(tile:)
       end
 
       it 'returns a 200 status code' do
+        do_get
+
         expect(response).to have_http_status(:ok)
       end
 
       it 'shows the tile' do
-        get :show, params: { id: tile.hashid }
+        do_get
 
         expect(response.body).to include(tile.w3w)
       end
 
       it 'shows a message that the tile is yours' do
-        get :show, params: { id: tile.hashid }
+        do_get
 
         expect(response.body).to include('Your subscription to this tile')
       end
     end
 
-    context 'with a tile subcribed by another user' do
+    context 'with a tile subscribed by another user' do
       before do
-        subscription.update!(subscriber: other_user, tile:)
+        subscription.update!(subscriber: create(:user), tile:)
       end
 
       it 'returns a 200 status code' do
+        do_get
+
         expect(response).to have_http_status(:ok)
       end
 
       it 'shows the tile' do
-        get :show, params: { id: tile.hashid }
+        do_get
 
         expect(response.body).to include(tile.w3w)
       end
 
       it 'shows a message that the tile is already claimed' do
-        get :show, params: { id: tile.hashid }
+        do_get
 
         expect(response.body).to include('already subscribed by someone else')
       end

--- a/spec/controllers/tiles_controller_show_spec.rb
+++ b/spec/controllers/tiles_controller_show_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe TilesController do
+  render_views
+
+  describe 'GET tiles#show' do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:subscription) { create(:subscription, subscriber: user) }
+    let(:project) { create(:project) }
+    let(:tile) { create(:tile) }
+
+    before do
+      sign_in(user)
+      tile
+    end
+
+    context 'when logged out' do
+      before do
+        sign_out(user)
+      end
+
+      it 'returns a 200 status code' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows login link' do
+        get :show, params: { id: tile.hashid }
+
+        expect(response.body).to include(new_user_session_path)
+      end
+
+      it 'shows the tile details anyway' do
+        get :show, params: { id: tile.hashid }
+
+        expect(response.body).to include(tile.w3w)
+      end
+    end
+
+    context 'with an unclaimed tile' do
+      it 'returns a 200 status code' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows the tile' do
+        get :show, params: { id: tile.hashid }
+
+        expect(response.body).to include(tile.w3w)
+      end
+    end
+
+    context 'with a tile subcribed by current user' do
+      before do
+        subscription.update!(tile:)
+      end
+
+      it 'returns a 200 status code' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows the tile' do
+        get :show, params: { id: tile.hashid }
+
+        expect(response.body).to include(tile.w3w)
+      end
+
+      it 'shows a message that the tile is yours' do
+        get :show, params: { id: tile.hashid }
+
+        expect(response.body).to include('Your subscription to this tile')
+      end
+    end
+
+    context 'with a tile subcribed by another user' do
+      before do
+        subscription.update!(subscriber: other_user, tile:)
+      end
+
+      it 'returns a 200 status code' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows the tile' do
+        get :show, params: { id: tile.hashid }
+
+        expect(response.body).to include(tile.w3w)
+      end
+
+      it 'shows a message that the tile is already claimed' do
+        get :show, params: { id: tile.hashid }
+
+        expect(response.body).to include('already subscribed by someone else')
+      end
+    end
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -3,5 +3,7 @@
 FactoryBot.define do
   factory :project do
     title { 'Test Project' }
+
+    logo_url { 'https://example.com/logo.png' }
   end
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :subscription do
     tile { nil }
-    user { nil }
+    subscriber { nil }
 
     sequence(:stripe_id) { |n| "sub_#{n}" }
     stripe_status { 'active' }

--- a/spec/models/plot_spec.rb
+++ b/spec/models/plot_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Plot do
 
     let(:user) { create(:user) }
     let(:tile) { create(:tile, plot:) }
-    let(:subscription) { create(:subscription, user:, tile:) }
+    let(:subscription) { create(:subscription, subscriber: user, tile:) }
 
     before { subscription }
 
@@ -34,7 +34,7 @@ RSpec.describe Plot do
     end
 
     it 'excludes tiles subscribed by another user' do
-      subscription.update!(user: create(:user))
+      subscription.update!(subscriber: create(:user))
 
       expect(tiles_subscribed.ids).to be_empty
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Project do
     let(:user) { create(:user) }
     let(:plot) { create(:plot, project:) }
     let(:tile) { create(:tile, plot:) }
-    let(:subscription) { create(:subscription, user:, tile:) }
+    let(:subscription) { create(:subscription, subscriber: user, tile:) }
 
     before { subscription }
 
@@ -31,7 +31,7 @@ RSpec.describe Project do
     end
 
     it 'returns false if tile subscribed by another user' do
-      subscription.update!(user: create(:user))
+      subscription.update!(subscriber: create(:user))
       tile.reload
 
       expect(viewable).to be false

--- a/spec/models/tile_spec.rb
+++ b/spec/models/tile_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Tile do
 
     let(:user) { create(:user) }
     let(:tile) { create(:tile) }
-    let(:subscription) { create(:subscription, user:, tile:) }
+    let(:subscription) { create(:subscription, subscriber: user, tile:) }
 
     before { subscription }
 
@@ -49,7 +49,7 @@ RSpec.describe Tile do
     end
 
     it 'returns false if tile subscribed by another user' do
-      subscription.update!(user: create(:user))
+      subscription.update!(subscriber: create(:user))
       tile.reload
 
       expect(viewable).to be false


### PR DESCRIPTION
In preparation for handling the splitting of "subscriber" and "beneficiary" for a subscription (to support gifting functionality), this PR renames the existing `user` association to `subscriber`.