### PR TITLE
Migrate to new rubocop plugin configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
-require:
+plugins:
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/plugin_migration_guide