### PR TITLE
Manually configure warden to resolve Rails 8 issue

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,13 @@ require 'webmock/rspec'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  # Fix issue since Rails 8 where first test raises an exception
+  # when trying to use Warden before any strategies have been set up.
+  # See: https://github.com/heartcombo/devise/issues/5771#issuecomment-2752689527
+  config.before(:suite) do
+    Devise.configure_warden!
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
A strange error manifested locally (not CI), when running the test suite.

The exception (locally) when running `docker-compose exec -e "RAILS_ENV=test"  app bin/rspec` is below.

```
ArgumentError:
  wrong number of arguments (given 1, expected 2)
# /usr/local/bundle/gems/devise-4.9.4/lib/devise/models/authenticatable.rb:241:in `serialize_from_session'
# /usr/local/bundle/gems/devise-4.9.4/lib/devise.rb:496:in `block (2 levels) in configure_warden!'
# /usr/local/bundle/gems/warden-1.2.9/lib/warden/session_serializer.rb:35:in `fetch'
# /usr/local/bundle/gems/warden-1.2.9/lib/warden/proxy.rb:224:in `user'
# /usr/local/bundle/gems/warden-1.2.9/lib/warden/proxy.rb:334:in `_perform_authentication'
# /usr/local/bundle/gems/warden-1.2.9/lib/warden/proxy.rb:133:in `authenticate!'
# /usr/local/bundle/gems/devise-4.9.4/lib/devise/controllers/helpers.rb:120:in `authenticate_user!'
# /usr/local/bundle/gems/devise-4.9.4/lib/devise/test/controller_helpers.rb:35:in `block in process'
# /usr/local/bundle/gems/devise-4.9.4/lib/devise/test/controller_helpers.rb:104:in `catch'
# /usr/local/bundle/gems/devise-4.9.4/lib/devise/test/controller_helpers.rb:104:in `_catch_warden'
# /usr/local/bundle/gems/devise-4.9.4/lib/devise/test/controller_helpers.rb:35:in `process'
# ./spec/controllers/admin/plots_controller_spec.rb:16:in `block (3 levels) in <main>'
# /usr/local/bundle/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```

Found the solution in [this comment](https://github.com/heartcombo/devise/issues/5771#issuecomment-2752689527) 🙏 