### PR TITLE
Ensure latest_subscription is updated on old and new tile

### DIFF
--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -39,9 +39,7 @@ module Admin
     def update
       @subscription.assign_attributes(subscription_params)
 
-      if @subscription.tile&.unavailable?(allow_cancelled: true)
-        @subscription.errors.add(:tile, 'is unavailable; unlink other subscriptions from it first')
-      end
+      validate_new_tile_availability
 
       # Do not use `valid?` as that would clear any error added above
       if @subscription.errors.none? && @subscription.save
@@ -78,6 +76,13 @@ module Admin
       return if old_tile_id.nil?
 
       Tile.find(old_tile_id).reset_latest_subscription!
+    end
+
+    def validate_new_tile_availability
+      return if @subscription.tile.nil?
+      return if @subscription.tile.available?(allow_cancelled: true)
+
+      @subscription.errors.add(:tile, 'is unavailable; unlink other subscriptions from it first')
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -37,12 +37,10 @@ module Admin
     end
 
     def update
-      old_tile = @subscription.tile
       @subscription.assign_attributes(subscription_params)
-      new_tile = @subscription.tile
 
-      if new_tile.present? && new_tile != old_tile
-        @subscription.errors.add(:tile, 'is already linked to another active subscription; unlink that first') if new_tile.subscriptions.any?(&:stripe_status_active?)
+      if @subscription.tile&.unavailable?(allow_cancelled: true)
+        @subscription.errors.add(:tile, 'is unavailable; unlink other subscriptions from it first')
       end
 
       # Do not use `valid?` as that would clear any error added above

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -47,7 +47,7 @@ module Admin
 
       # Do not use `valid?` as that would clear any error added above
       if @subscription.errors.none? && @subscription.save
-        old_tile&.reset_latest_subscription! if old_tile != new_tile
+        reset_previous_tile_latest_subscription
 
         redirect_to admin_subscription_path(@subscription), notice: 'Subscription was successfully updated.'
       else
@@ -71,6 +71,15 @@ module Admin
 
     def subscription_params
       subscription_params_parsed.require(:subscription).permit(:subscriber_id, :redeemer_id, :tile_id, :project_id)
+    end
+
+    def reset_previous_tile_latest_subscription
+      return unless @subscription.previous_changes.key?(:tile_id)
+
+      old_tile_id = @subscription.previous_changes.dig(:tile_id, 0)
+      return if old_tile_id.nil?
+
+      Tile.find(old_tile_id).reset_latest_subscription!
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -47,7 +47,7 @@ module Admin
 
       # Do not use `valid?` as that would clear any error added above
       if @subscription.errors.none? && @subscription.save
-        old_tile&.reset_latest_subscription! if old_tile.present? && old_tile != new_tile
+        old_tile&.reset_latest_subscription! if old_tile != new_tile
 
         redirect_to admin_subscription_path(@subscription), notice: 'Subscription was successfully updated.'
       else

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -23,9 +23,16 @@ class Subscription < ApplicationRecord
   # TODO: Migrate to prices table (subscription.price.amount_display)
   monetize :price_pence, as: :price, numericality: { greater_than: 0 }, allow_nil: true
 
+  before_destroy :wipe_latest_subscription
   after_save :reset_tile_latest_subscription
 
   EXTERNALLY_PAID_PREFIX = 'sub_externallypaid'
+
+  def wipe_latest_subscription
+    return unless tile&.latest_subscription == self
+
+    tile.update!(latest_subscription: nil)
+  end
 
   def reset_tile_latest_subscription
     tile&.reset_latest_subscription!

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -23,21 +23,12 @@ class Subscription < ApplicationRecord
   # TODO: Migrate to prices table (subscription.price.amount_display)
   monetize :price_pence, as: :price, numericality: { greater_than: 0 }, allow_nil: true
 
-  before_destroy :wipe_latest_subscription
-  after_save :assign_latest_subscription
+  after_save :reset_tile_latest_subscription
 
   EXTERNALLY_PAID_PREFIX = 'sub_externallypaid'
 
-  def assign_latest_subscription
-    return if tile.nil?
-
-    tile.update!(latest_subscription: tile.subscriptions.order(id: :desc).first)
-  end
-
-  def wipe_latest_subscription
-    return if tile.nil? || tile.latest_subscription != self
-
-    tile&.update!(latest_subscription: nil)
+  def reset_tile_latest_subscription
+    tile&.reset_latest_subscription!
   end
 
   def verify_claims_hash(provided_hash)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -28,14 +28,14 @@ class Subscription < ApplicationRecord
 
   EXTERNALLY_PAID_PREFIX = 'sub_externallypaid'
 
+  def reset_tile_latest_subscription
+    tile&.reset_latest_subscription!
+  end
+
   def wipe_latest_subscription
     return unless tile&.latest_subscription == self
 
     tile.update!(latest_subscription: nil)
-  end
-
-  def reset_tile_latest_subscription
-    tile&.reset_latest_subscription!
   end
 
   def verify_claims_hash(provided_hash)

--- a/app/models/tile.rb
+++ b/app/models/tile.rb
@@ -10,7 +10,7 @@ class Tile < ApplicationRecord
   belongs_to :plot, optional: true
   has_many :subscriptions, dependent: :restrict_with_exception
 
-  has_many :previous_subscriptions, ->(tile) { where.not(subscriptions: { id: tile.latest_subscription_id }) }, class_name: 'Subscription', inverse_of: :tile, dependent: :nullify
+  has_many :previous_subscriptions, ->(tile) { where.not(subscriptions: { id: tile.latest_subscription_id }) }, class_name: 'Subscription', inverse_of: :tile, dependent: :restrict_with_exception
   belongs_to :latest_subscription, class_name: 'Subscription', optional: true
   has_many :post_associations, as: :postable, inverse_of: :postable, dependent: :restrict_with_exception
   has_many :posts, through: :post_associations
@@ -27,6 +27,10 @@ class Tile < ApplicationRecord
   auto_strip_attributes :w3w, squish: true
 
   delegate :project, to: :plot, allow_nil: true
+
+  def reset_latest_subscription!
+    update!(latest_subscription: subscriptions.order(id: :desc).first)
+  end
 
   def to_geojson
     geojson = RGeo::GeoJSON.encode(bounding_box.to_geometry)

--- a/app/models/tile.rb
+++ b/app/models/tile.rb
@@ -45,17 +45,18 @@ class Tile < ApplicationRecord
     geojson.to_json
   end
 
-  def available?
+  def available?(allow_cancelled: false)
     return true if latest_subscription.nil?
     return true if latest_subscription.new_record? # handle display on 'new' screen
 
-    # TODO: consider 'cancelled' etc as available again? Perhaps only if not re-subscribed again (by the same user)?
-    # Perhaps this becomes available_to?(user) and that allows snatching the tile again after subscription lapses, within a set time?
+    # Anyone else can subscribe once a tile's subscription is cancelled.
+    return true if allow_cancelled && latest_subscription.stripe_status_canceled?
+
     false
   end
 
-  def unavailable?
-    !available?
+  def unavailable?(allow_cancelled: false)
+    !available?(allow_cancelled:)
   end
 
   def popup_content

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Admin::SubscriptionsController do
       it 'returns an error' do
         do_patch
 
-        expect(response.body).to include('already linked to another active subscription')
+        expect(response.body).to include('Tile is unavailable')
       end
 
       it 'allows update if the other subscription was cancelled' do


### PR DESCRIPTION
When updating a subscription to change (or unset) the tile, the old tile would retain the "latest_subscription" link to this subscription, even though it was no longer associated with the subscription. This fixes that!