### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@
 
 name: Lint
 
+permissions:
+  contents: read
+
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/landgrab/landgrab/security/code-scanning/2](https://github.com/landgrab/landgrab/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only runs linters and static analysis tools, it likely only needs `contents: read` permissions. This ensures that the workflow cannot modify repository contents or perform other write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
