### PR TITLE
Fix Stripe CheckoutSession Race Condition

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -64,7 +64,6 @@ class CheckoutController < ApplicationController
 
   def stripe_checkout_payload
     x = {
-      # Stripe will create new customer if not supplied
       customer: current_user.stripe_customer_id,
       line_items: [{
         price: @price.stripe_id,
@@ -84,8 +83,7 @@ class CheckoutController < ApplicationController
   end
 
   def stripe_checkout_payload_subscription_data
-    # Data to be stored with the subscription
-    # https://docs.stripe.com/api/checkout/sessions/create#create_checkout_session-subscription_data-metadata
+    # Data to be stored with the subscription: https://docs.stripe.com/api/checkout/sessions/create#create_checkout_session-subscription_data-metadata
     {
       metadata: {
         project: @project.hashid,
@@ -130,9 +128,9 @@ class CheckoutController < ApplicationController
   end
 
   def retrieve_authorised_checkout_session
-    session = Stripe::Checkout::Session.retrieve(params[:session_id]).tap do |session|
+    Stripe::Checkout::Session.retrieve(params[:session_id]).tap do |session|
       unless current_user.stripe_customer_id == session.customer
-        raise "Stripe Customer ID mismatch: current user '#{current_user.id}' has Stripe ID '#{current_user.stripe_customer_id}' but completed checkout had '#{session.customer}' (session '#{session.id}')"
+        raise "Customer mismatch for User##{current_user.hashid}; user_cust=#{current_user.stripe_customer_id}; session_cust=#{session.customer} (session_id=#{session.id})"
       end
     end
   end

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -69,7 +69,7 @@ class CheckoutController < ApplicationController
         price: @price.stripe_id,
         quantity: 1
       }],
-      subscription_data: stripe_checkout_payload_subscription_data,
+      subscription_data: { metadata: stripe_checkout_payload_subscription_metadata },
       mode: 'subscription',
       ui_mode: 'embedded',
       return_url: build_success_url
@@ -82,14 +82,12 @@ class CheckoutController < ApplicationController
     x
   end
 
-  def stripe_checkout_payload_subscription_data
+  def stripe_checkout_payload_subscription_metadata
     # Data to be stored with the subscription: https://docs.stripe.com/api/checkout/sessions/create#create_checkout_session-subscription_data-metadata
     {
-      metadata: {
-        project: @project.hashid,
-        tile: @tile&.hashid,
-        CheckoutService::REDEMPTION_MODE_KEY => @redemption_mode
-      }
+      project: @project.hashid,
+      tile: @tile&.hashid,
+      CheckoutService::REDEMPTION_MODE_KEY => @redemption_mode
     }
   end
 

--- a/spec/controllers/checkout_controller_success_spec.rb
+++ b/spec/controllers/checkout_controller_success_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CheckoutController do
         do_get
 
         expect(response).to redirect_to(checkout_checkout_url)
-        expect(flash[:danger]).to include('try again')
+        expect(flash[:danger]).to include('not completed')
       end
     end
 
@@ -81,7 +81,7 @@ RSpec.describe CheckoutController do
         do_get
 
         expect(response).to redirect_to(project_path(project))
-        expect(flash[:success]).to include('Your subscription has been successfully set up!')
+        expect(flash[:success]).to include('Subscription created successfully!')
       end
 
       it 'redirects to tile if set' do
@@ -90,7 +90,7 @@ RSpec.describe CheckoutController do
         do_get
 
         expect(response).to redirect_to(tile_path(tile))
-        expect(flash[:success]).to include('Your subscription has been successfully set up!')
+        expect(flash[:success]).to include('Subscription created successfully!')
       end
     end
   end


### PR DESCRIPTION
There seems to be an intermittent race condition when a user returns successfully from a CheckoutSession. The code retrieves the session from the Stripe API but it does not yet have the "subscription" object attached to it, so an exception is raised.

The (attempted) solution is to wait up to 5 seconds, retrying every second, until the subscription is attached.

I've not been able to reproduce this locally ...
